### PR TITLE
Negative Marking Settings And Custom User Defined Methods To Evaluate A Question Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .phpunit.result.cache
 logfile.txt
+.vscode/

--- a/config/config.php
+++ b/config/config.php
@@ -15,5 +15,10 @@ return [
         'quiz_attempts' => 'quiz_attempts',
         'quiz_attempt_answers' => 'quiz_attempt_answers',
     ],
+    'answer_pickers' => [
+        1 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_correct_answer_type_one',
+        2 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_correct_answer_type_two',
+        3 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_correct_answer_type_three',
+    ]
 
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -15,10 +15,10 @@ return [
         'quiz_attempts' => 'quiz_attempts',
         'quiz_attempt_answers' => 'quiz_attempt_answers',
     ],
-    'answer_pickers' => [
-        1 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_correct_answer_type_one',
-        2 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_correct_answer_type_two',
-        3 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_correct_answer_type_three',
+    'get_score_for_question_type' => [
+        1 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_score_for_type_1_question',
+        2 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_score_for_type_2_question',
+        3 => '\Harishdurga\LaravelQuiz\Models\QuizAttempt::get_score_for_type_3_question',
     ]
 
 ];

--- a/database/factories/QuizFactory.php
+++ b/database/factories/QuizFactory.php
@@ -17,7 +17,6 @@ class QuizFactory extends Factory
             'title' => $title,
             'slug' => Str::slug($title),
             'description' => $this->faker->paragraph,
-            'media_url' => $this->faker->url,
             'total_marks' => 0,
             'pass_marks' => 0,
             'max_attempts' => 0,
@@ -26,7 +25,12 @@ class QuizFactory extends Factory
             'media_type' => 'image',
             'duration' => 0,
             'valid_from' => date('Y-m-d H:i:s'),
-            'valid_upto' => null
+            'valid_upto' => null,
+            'negative_marking_settings' => [
+                'enable_negative_marks' => false,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]
         ];
     }
 }

--- a/database/factories/QuizFactory.php
+++ b/database/factories/QuizFactory.php
@@ -27,7 +27,7 @@ class QuizFactory extends Factory
             'valid_from' => date('Y-m-d H:i:s'),
             'valid_upto' => null,
             'negative_marking_settings' => [
-                'enable_negative_marks' => false,
+                'enable_negative_marks' => true,
                 'negative_marking_type' => 'fixed',
                 'negative_mark_value' => 0,
             ]

--- a/database/migrations/2022_05_27_163432_add_negative_marks_columns_to_quiz_questions_table.php
+++ b/database/migrations/2022_05_27_163432_add_negative_marks_columns_to_quiz_questions_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public array $tableNames;
+    public function __construct()
+    {
+        $this->tableNames = config('laravel-quiz.table_names');
+    }
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table($this->tableNames['quizzes'], function (Blueprint $table) {
+            $table->json('negative_marking_settings')->default(json_encode([
+                'enable_negative_marks' => false,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]))->after('pass_marks');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table($this->tableNames['quizzes'], function (Blueprint $table) {
+            $table->dropColumn('negative_marking_settings');
+        });
+    }
+};

--- a/database/migrations/2022_05_27_163432_add_negative_marks_columns_to_quiz_questions_table.php
+++ b/database/migrations/2022_05_27_163432_add_negative_marks_columns_to_quiz_questions_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
     {
         Schema::table($this->tableNames['quizzes'], function (Blueprint $table) {
             $table->json('negative_marking_settings')->default(json_encode([
-                'enable_negative_marks' => false,
+                'enable_negative_marks' => true,
                 'negative_marking_type' => 'fixed',
                 'negative_mark_value' => 0,
             ]))->after('pass_marks');

--- a/src/Models/Quiz.php
+++ b/src/Models/Quiz.php
@@ -6,11 +6,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+
 class Quiz extends Model
 {
     use HasFactory, SoftDeletes;
     protected $guarded = ['id'];
-
+    const FIXED_NEGATIVE_TYPE = 'fixed';
+    const PERCENTAGE_NEGATIVE_TYPE = 'percentage';
     /**
      * The attributes that should be cast.
      *

--- a/src/Models/Quiz.php
+++ b/src/Models/Quiz.php
@@ -11,6 +11,14 @@ class Quiz extends Model
     use HasFactory, SoftDeletes;
     protected $guarded = ['id'];
 
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'negative_marking_settings' => 'json',
+    ];
 
     public function getTable()
     {

--- a/src/Models/QuizAttempt.php
+++ b/src/Models/QuizAttempt.php
@@ -45,11 +45,9 @@ class QuizAttempt extends Model
         foreach ($this->answers as $key => $quiz_attempt_answer) {
             $quiz_attempt_answers[$quiz_attempt_answer->quiz_question_id][] = $quiz_attempt_answer;
         }
-        // print_r($quiz_attempt_answers);
         foreach ($quiz_questions_collection as $quiz_question) {
             $question = $quiz_question->question;
             $score += call_user_func_array(config('laravel-quiz.get_score_for_question_type')[$question->question_type_id], [$this, $quiz_question, $quiz_attempt_answers[$quiz_question->id] ?? [], $data]);
-            print_r("Score : $score \n");
         }
         return $score;
     }
@@ -63,7 +61,6 @@ class QuizAttempt extends Model
         $question = $quizQuestion->question;
         $correct_answer = ($question->correct_options())->first()->id;
         $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
-        print_r(sprintf("Question Type: 1, Correct Answer: %s, Negative Marks:%s \n", $correct_answer, $negative_marks));
         if (!empty($correct_answer)) {
             if (count($quizQuestionAnswers)) {
                 return $quizQuestionAnswers[0]->question_option_id == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
@@ -84,14 +81,12 @@ class QuizAttempt extends Model
         $question = $quizQuestion->question;
         $correct_answer = ($question->correct_options())->pluck('id');
         $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
-        print_r(sprintf("Question Type: 2, Correct Answer: %s, Negative Marks:%s \n", $correct_answer, $negative_marks));
         if (!empty($correct_answer)) {
             if (count($quizQuestionAnswers)) {
                 $temp_arr = [];
                 foreach ($quizQuestionAnswers as  $answer) {
                     $temp_arr[] = $answer->question_option_id;
                 }
-                print_r($temp_arr, "Temp Arr \n");
                 return $correct_answer->toArray() == $temp_arr ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
             } else {
                 return $quizQuestion->is_optional ? 0 : -$negative_marks; // If the question is optional, then the negative marks will be 0
@@ -110,7 +105,6 @@ class QuizAttempt extends Model
         $question = $quizQuestion->question;
         $correct_answer = ($question->correct_options())->first()->option;
         $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
-        print_r(sprintf("Question Type: 3, Correct Answer: %s, Negative Marks:%s \n", $correct_answer, $negative_marks));
         if (!empty($correct_answer)) {
             if (count($quizQuestionAnswers)) {
                 return  $quizQuestionAnswers[0]->answer == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
@@ -124,7 +118,11 @@ class QuizAttempt extends Model
 
     public static function get_negative_marks_for_question(Quiz $quiz, QuizQuestion $quizQuestion): float
     {
-        $negative_marking_settings = $quiz->negative_marking_settings;
+        $negative_marking_settings = $quiz->negative_marking_settings ?? [
+            'enable_negative_marks' => true,
+            'negative_marking_type' => 'fixed',
+            'negative_mark_value' => 0,
+        ];
         if (!$negative_marking_settings['enable_negative_marks']) { // If negative marking is disabled
             return 0;
         }

--- a/src/Models/QuizAttempt.php
+++ b/src/Models/QuizAttempt.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * @property Quiz $quiz
+ */
 class QuizAttempt extends Model
 {
     use SoftDeletes;
@@ -16,6 +19,9 @@ class QuizAttempt extends Model
         return config('laravel-quiz.table_names.quiz_attempts');
     }
 
+    /**
+     * @return \Harishdurga\LaravelQuiz\Models\Quiz
+     */
     public function quiz()
     {
         return $this->belongsTo(Quiz::class);
@@ -31,108 +37,95 @@ class QuizAttempt extends Model
         return $this->hasMany(QuizAttemptAnswer::class);
     }
 
-    public function caclculate_score(): float
+    public function caclculate_score($data = null): float
     {
         $score = 0;
-        $quiz_questions_collection = $this->quiz->questions()->with('question')->get();
-        $quiz_questions = [];
+        $quiz_questions_collection = $this->quiz->questions()->with('question')->orderBy('id', 'ASC')->get();
         $quiz_attempt_answers = [];
-        foreach ($quiz_questions_collection as $key => $quiz_question) {
-            $question = $quiz_question->question;
-            if (isset(config('laravel-quiz.answer_pickers')[$question->question_type_id])) {
-                $correct_answer = call_user_func_array(config('laravel-quiz.answer_pickers')[$question->question_type_id], [$question]);
-            } else {
-                $correct_answer = null;
-            }
-            $quiz_questions[$quiz_question->id] = [
-                'question_type_id' => $question->question_type_id,
-                'is_optional' => $quiz_question->is_optional,
-                'marks' => $quiz_question->marks,
-                'negative_marks' => $quiz_question->negative_marks,
-                'correct_answer' => $correct_answer
-            ];
-        }
         foreach ($this->answers as $key => $quiz_attempt_answer) {
-            $quiz_attempt_answers[$quiz_attempt_answer->quiz_question_id][] = ['option_id' => $quiz_attempt_answer->question_option_id, 'answer' => $quiz_attempt_answer->answer];
+            $quiz_attempt_answers[$quiz_attempt_answer->quiz_question_id][] = $quiz_attempt_answer;
         }
-        foreach ($quiz_questions as $quiz_question_id => $quiz_question) {
-            if ($quiz_question['question_type_id'] == 1) {
-                if (!empty($quiz_question['correct_answer'])) {
-                    if (isset($quiz_attempt_answers[$quiz_question_id])) {
-                        if ($quiz_attempt_answers[$quiz_question_id][0]['option_id'] == $quiz_question['correct_answer']) {
-                            $score += $quiz_question['marks'];
-                        } else {
-                            $score -= $quiz_question['negative_marks'];
-                        }
-                    } else {
-                        if (!$quiz_question['is_optional']) {
-                            $score -= $quiz_question['negative_marks'];
-                        }
-                    }
-                } else {
-                    if (isset($quiz_attempt_answers[$quiz_question_id])) {
-                        $score += $quiz_question['marks'];
-                    }
-                }
-            } elseif ($quiz_question['question_type_id'] == 2) {
-                if (!empty($quiz_question['correct_answer'])) {
-                    if (isset($quiz_attempt_answers[$quiz_question_id])) {
-                        $temp_arr = [];
-                        foreach ($quiz_attempt_answers[$quiz_question_id] as $key => $answer) {
-                            $temp_arr[] = $answer['option_id'];
-                        }
-                        if ($quiz_question['correct_answer']->toArray() == $temp_arr) {
-                            $score += $quiz_question['marks'];
-                        } else {
-                            $score -= $quiz_question['negative_marks'];
-                        }
-                    } else {
-                        if (!$quiz_question['is_optional']) {
-                            $score -= $quiz_question['negative_marks'];
-                        }
-                    }
-                } else {
-                    if (isset($quiz_attempt_answers[$quiz_question_id])) {
-                        $score += $quiz_question['marks'];
-                    }
-                }
-            } elseif ($quiz_question['question_type_id'] == 3) {
-                if (!empty($quiz_question['correct_answer'])) {
-                    if (isset($quiz_attempt_answers[$quiz_question_id])) {
-                        if ($quiz_question['correct_answer'] == $quiz_attempt_answers[$quiz_question_id][0]['answer']) {
-                            $score += $quiz_question['marks'];
-                        } else {
-                            $score -= $quiz_question['negative_marks'];
-                        }
-                    } else {
-                        if (!$quiz_question['is_optional']) {
-                            $score -= $quiz_question['negative_marks'];
-                        }
-                    }
-                } else {
-                    if (isset($quiz_attempt_answers[$quiz_question_id])) {
-                        $score += $quiz_question['marks'];
-                    }
-                }
-            } else {
-                $score += $quiz_question['marks'];
-            }
+        foreach ($quiz_questions_collection as $quiz_question) {
+            $question = $quiz_question->question;
+            $score += call_user_func_array(config('laravel-quiz.get_score_for_question_type')[$question->question_type_id], [$this, $quiz_question, $quiz_attempt_answers[$quiz_question->id], $data]);
         }
         return $score;
     }
 
-    public static function get_correct_answer_type_one(Question $question)
+    /**
+     * @param QuizAttemptAnswer[] $quizQuestionAnswers All the answers of the quiz question
+     */
+    public static function get_score_for_type_1_question(QuizAttempt $quizAttempt, QuizQuestion $quizQuestion, array $quizQuestionAnswers, $data = null): float
     {
-        return ($question->correct_options())->first()->id;
+        $quiz = $quizAttempt->quiz;
+        $question = $quizQuestion->question;
+        $correct_answer = ($question->correct_options())->first()->id;
+        $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
+        if (!empty($correct_answer)) {
+            if (count($quizQuestionAnswers)) {
+                return $quizQuestionAnswers[0]->option_id == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
+            } else {
+                return $quizQuestion->is_optional ? 0 : -$negative_marks; // If the question is optional, then the negative marks will be 0
+            }
+        } else {
+            return count($quizQuestionAnswers) ? floatval($quizQuestion->marks) : 0; // Incase of no correct answer, if there is any answer then give full marks
+        }
     }
 
-    public static function get_correct_answer_type_two(Question $question)
+    /**
+     * @param QuizAttemptAnswer[] $quizQuestionAnswers All the answers of the quiz question
+     */
+    public static function get_score_for_type_2_question(QuizAttempt $quizAttempt, QuizQuestion $quizQuestion, array $quizQuestionAnswers, $data = null): float
     {
-        return ($question->correct_options())->pluck('id');
+        $quiz = $quizAttempt->quiz;
+        $question = $quizQuestion->question;
+        $correct_answer = ($question->correct_options())->pluck('id');
+        $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
+        if (!empty($correct_answer)) {
+            if (count($quizQuestionAnswers)) {
+                $temp_arr = [];
+                foreach ($quizQuestionAnswers as  $answer) {
+                    $temp_arr[] = $answer->option_id;
+                }
+                return $correct_answer->toArray() == $temp_arr ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
+            } else {
+                return $quizQuestion->is_optional ? 0 : -$negative_marks; // If the question is optional, then the negative marks will be 0
+            }
+        } else {
+            return count($quizQuestionAnswers) ? floatval($quizQuestion->marks) : 0; // Incase of no correct answer, if there is any answer then give full marks
+        }
     }
 
-    public static function get_correct_answer_type_three(Question $question)
+    /**
+     * @param QuizAttemptAnswer[] $quizQuestionAnswers All the answers of the quiz question
+     */
+    public static function get_score_for_type_3_question(QuizAttempt $quizAttempt, QuizQuestion $quizQuestion, array $quizQuestionAnswers, $data = null): float
     {
-        return ($question->correct_options())->first()->option;
+        $quiz = $quizAttempt->quiz;
+        $question = $quizQuestion->question;
+        $correct_answer = ($question->correct_options())->pluck('id');
+        $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
+        if (!empty($correct_answer)) {
+            if (count($quizQuestionAnswers)) {
+                return  $quizQuestionAnswers[0]->answer == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
+            } else {
+                return $quizQuestion->is_optional ? 0 : -$negative_marks; // If the question is optional, then the negative marks will be 0
+            }
+        } else {
+            return count($quizQuestionAnswers) ? floatval($quizQuestion->marks) : 0; // Incase of no correct answer, if there is any answer then give full marks
+        }
+    }
+
+    public static function get_negative_marks_for_question(Quiz $quiz, QuizQuestion $quizQuestion): float
+    {
+        $negative_marking_settings = $quiz->negative_marking_settings;
+        if (!$negative_marking_settings['enable_negative_marks']) { // If negative marking is disabled
+            return 0;
+        }
+        if (!empty($quizQuestion->negative_marks)) {
+            return $negative_marking_settings['negative_marking_type'] == 'fixed' ? $quizQuestion->negative_marks : ($quizQuestion->marks * ($quizQuestion->negative_marks / 100));
+        } else {
+            return $negative_marking_settings['negative_marking_type'] == 'fixed' ? $negative_marking_settings['negative_mark_value'] : ($quizQuestion->marks * ($negative_marking_settings['negative_mark_value'] / 100));
+        }
     }
 }

--- a/src/Models/QuizAttempt.php
+++ b/src/Models/QuizAttempt.php
@@ -45,9 +45,11 @@ class QuizAttempt extends Model
         foreach ($this->answers as $key => $quiz_attempt_answer) {
             $quiz_attempt_answers[$quiz_attempt_answer->quiz_question_id][] = $quiz_attempt_answer;
         }
+        // print_r($quiz_attempt_answers);
         foreach ($quiz_questions_collection as $quiz_question) {
             $question = $quiz_question->question;
-            $score += call_user_func_array(config('laravel-quiz.get_score_for_question_type')[$question->question_type_id], [$this, $quiz_question, $quiz_attempt_answers[$quiz_question->id], $data]);
+            $score += call_user_func_array(config('laravel-quiz.get_score_for_question_type')[$question->question_type_id], [$this, $quiz_question, $quiz_attempt_answers[$quiz_question->id] ?? [], $data]);
+            print_r("Score : $score \n");
         }
         return $score;
     }
@@ -61,9 +63,10 @@ class QuizAttempt extends Model
         $question = $quizQuestion->question;
         $correct_answer = ($question->correct_options())->first()->id;
         $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
+        print_r(sprintf("Question Type: 1, Correct Answer: %s, Negative Marks:%s \n", $correct_answer, $negative_marks));
         if (!empty($correct_answer)) {
             if (count($quizQuestionAnswers)) {
-                return $quizQuestionAnswers[0]->option_id == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
+                return $quizQuestionAnswers[0]->question_option_id == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
             } else {
                 return $quizQuestion->is_optional ? 0 : -$negative_marks; // If the question is optional, then the negative marks will be 0
             }
@@ -81,12 +84,14 @@ class QuizAttempt extends Model
         $question = $quizQuestion->question;
         $correct_answer = ($question->correct_options())->pluck('id');
         $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
+        print_r(sprintf("Question Type: 2, Correct Answer: %s, Negative Marks:%s \n", $correct_answer, $negative_marks));
         if (!empty($correct_answer)) {
             if (count($quizQuestionAnswers)) {
                 $temp_arr = [];
                 foreach ($quizQuestionAnswers as  $answer) {
-                    $temp_arr[] = $answer->option_id;
+                    $temp_arr[] = $answer->question_option_id;
                 }
+                print_r($temp_arr, "Temp Arr \n");
                 return $correct_answer->toArray() == $temp_arr ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks
             } else {
                 return $quizQuestion->is_optional ? 0 : -$negative_marks; // If the question is optional, then the negative marks will be 0
@@ -103,8 +108,9 @@ class QuizAttempt extends Model
     {
         $quiz = $quizAttempt->quiz;
         $question = $quizQuestion->question;
-        $correct_answer = ($question->correct_options())->pluck('id');
+        $correct_answer = ($question->correct_options())->first()->option;
         $negative_marks = self::get_negative_marks_for_question($quiz, $quizQuestion);
+        print_r(sprintf("Question Type: 3, Correct Answer: %s, Negative Marks:%s \n", $correct_answer, $negative_marks));
         if (!empty($correct_answer)) {
             if (count($quizQuestionAnswers)) {
                 return  $quizQuestionAnswers[0]->answer == $correct_answer ? $quizQuestion->marks : - ($negative_marks); // Return marks in case of correct answer else negative marks

--- a/src/Models/QuizAttempt.php
+++ b/src/Models/QuizAttempt.php
@@ -39,13 +39,8 @@ class QuizAttempt extends Model
         $quiz_attempt_answers = [];
         foreach ($quiz_questions_collection as $key => $quiz_question) {
             $question = $quiz_question->question;
-            $correct_answer = null;
-            if ($question->question_type_id == 1) {
-                $correct_answer =  ($question->correct_options())->first()->id;
-            } elseif ($question->question_type_id == 2) {
-                $correct_answer =  ($question->correct_options())->pluck('id');
-            } elseif ($question->question_type_id == 3) {
-                $correct_answer = ($question->correct_options())->first()->option;
+            if (isset(config('laravel-quiz.answer_pickers')[$question->question_type_id])) {
+                $correct_answer = call_user_func_array(config('laravel-quiz.answer_pickers')[$question->question_type_id], [$question]);
             } else {
                 $correct_answer = null;
             }
@@ -124,5 +119,20 @@ class QuizAttempt extends Model
             }
         }
         return $score;
+    }
+
+    public static function get_correct_answer_type_one(Question $question)
+    {
+        return ($question->correct_options())->first()->id;
+    }
+
+    public static function get_correct_answer_type_two(Question $question)
+    {
+        return ($question->correct_options())->pluck('id');
+    }
+
+    public static function get_correct_answer_type_three(Question $question)
+    {
+        return ($question->correct_options())->first()->option;
     }
 }

--- a/tests/Unit/QuizAttemptTest.php
+++ b/tests/Unit/QuizAttemptTest.php
@@ -1,0 +1,587 @@
+<?php
+
+namespace Harishdurga\LaravelQuiz\Tests\Unit;
+
+use Harishdurga\LaravelQuiz\Models\Quiz;
+use Harishdurga\LaravelQuiz\Tests\TestCase;
+use Harishdurga\LaravelQuiz\Models\Question;
+use Harishdurga\LaravelQuiz\Models\QuizAttempt;
+use Harishdurga\LaravelQuiz\Models\QuestionType;
+use Harishdurga\LaravelQuiz\Models\QuizQuestion;
+use Harishdurga\LaravelQuiz\Tests\Models\Author;
+use Harishdurga\LaravelQuiz\Models\QuestionOption;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Harishdurga\LaravelQuiz\Models\QuizAttemptAnswer;
+
+
+class QuizAttemptTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function get_score_for_type_1_question_no_negative_marks()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'How many layers in OSI model?',
+            'question_type_id' => 1,
+            'is_active' => false,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '5',
+            'is_correct' => false,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '8',
+            'is_correct' => false,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '10',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '7',
+            'is_correct' => true,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => false,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 5,
+            'order' => 1,
+            'negative_marks' => 1,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer = QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_four->id,
+            ]
+        );
+        $this->assertEquals(5, QuizAttempt::get_score_for_type_1_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer]));
+    }
+
+    /** @test */
+    function get_score_for_type_1_question_with_negative_marks_question_fixed()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'How many layers in OSI model?',
+            'question_type_id' => 1,
+            'is_active' => false,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '5',
+            'is_correct' => false,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '8',
+            'is_correct' => false,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '10',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '7',
+            'is_correct' => true,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => true,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 5,
+            'order' => 1,
+            'negative_marks' => 1,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer = QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_three->id,
+            ]
+        );
+        $this->assertEquals(-1, QuizAttempt::get_score_for_type_1_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer]));
+    }
+
+    /** @test */
+    function get_score_for_type_1_question_with_negative_marks_question_percentage()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'How many layers in OSI model?',
+            'question_type_id' => 1,
+            'is_active' => false,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '5',
+            'is_correct' => false,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '8',
+            'is_correct' => false,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '10',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '7',
+            'is_correct' => true,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => true,
+                'negative_marking_type' => 'percentage',
+                'negative_mark_value' => 0,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 5,
+            'order' => 1,
+            'negative_marks' => 10,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer = QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_three->id,
+            ]
+        );
+        $this->assertEquals(-0.5, QuizAttempt::get_score_for_type_1_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer]));
+    }
+
+    /** @test */
+    function get_score_for_type_1_question_with_negative_marks_quiz_fixed()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'How many layers in OSI model?',
+            'question_type_id' => 1,
+            'is_active' => false,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '5',
+            'is_correct' => false,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '8',
+            'is_correct' => false,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '10',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '7',
+            'is_correct' => true,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => true,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 2,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 10,
+            'order' => 1,
+            'negative_marks' => 0,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer = QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_three->id,
+            ]
+        );
+        $this->assertEquals(-2, QuizAttempt::get_score_for_type_1_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer]));
+    }
+
+    /** @test */
+    function get_score_for_type_1_question_with_negative_marks_quiz_percentage()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'How many layers in OSI model?',
+            'question_type_id' => 1,
+            'is_active' => false,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '5',
+            'is_correct' => false,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '8',
+            'is_correct' => false,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '10',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => '7',
+            'is_correct' => true,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => true,
+                'negative_marking_type' => 'percentage',
+                'negative_mark_value' => 5,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 10,
+            'order' => 1,
+            'negative_marks' => 0,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer = QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_three->id,
+            ]
+        );
+        $this->assertEquals(-0.5, QuizAttempt::get_score_for_type_1_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer]));
+    }
+
+    /** @test */
+    function get_score_for_type_2_question_no_negative_marks()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'Which of the below is a data structure?',
+            'question_type_id' => 2,
+            'is_active' => true,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'array',
+            'is_correct' => true,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'object',
+            'is_correct' => true,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'for loop',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'method',
+            'is_correct' => false,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => false,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 8,
+            'order' => 1,
+            'negative_marks' => 2,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+            ]
+        );
+        $quiz_attempt_answer_two = QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_two->id,
+            ]
+        );
+        $this->assertEquals(8, QuizAttempt::get_score_for_type_2_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one, $quiz_attempt_answer_two]));
+    }
+
+    /** @test */
+    function get_score_for_type_2_question_with_negative_marks_question_fixed()
+    {
+        $user = Author::create(
+            ['name' => "John Doe"]
+        );
+        //Question Types
+        QuestionType::insert(
+            [
+                [
+                    'question_type' => 'multiple_choice_single_answer',
+                ],
+                [
+                    'question_type' => 'multiple_choice_multiple_answer',
+                ],
+                [
+                    'question_type' => 'fill_the_blank',
+                ]
+            ]
+        );
+        //Question And Options
+        $question = Question::factory()->create([
+            'question' => 'Which of the below is a data structure?',
+            'question_type_id' => 2,
+            'is_active' => true,
+        ]);
+
+        $question_option_one = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'array',
+            'is_correct' => true,
+        ]);
+        $question_option_two = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'object',
+            'is_correct' => true,
+        ]);
+        $question_option_three = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'for loop',
+            'is_correct' => false,
+        ]);
+        $question_option_four = QuestionOption::factory()->create([
+            'question_id' => $question->id,
+            'option' => 'method',
+            'is_correct' => false,
+        ]);
+        $quiz = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => false,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]
+        ]);
+        $quiz_question =  QuizQuestion::factory()->create([
+            'quiz_id' => $quiz->id,
+            'question_id' => $question->id,
+            'marks' => 8,
+            'order' => 1,
+            'negative_marks' => 2,
+        ]);
+        //Quiz Attempt And Answers
+        $quiz_attempt = QuizAttempt::create([
+            'quiz_id' => $quiz->id,
+            'participant_id' => $user->id,
+            'participant_type' => get_class($user)
+        ]);
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+            ]
+        );
+        // $quiz_attempt_answer_two = QuizAttemptAnswer::create(
+        //     [
+        //         'quiz_attempt_id' => $quiz_attempt->id,
+        //         'quiz_question_id' => $quiz_question->id,
+        //         'question_option_id' => $question_option_two->id,
+        //     ]
+        // );
+        $this->assertEquals(-2, QuizAttempt::get_score_for_type_2_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+}

--- a/tests/Unit/QuizAttemptTest.php
+++ b/tests/Unit/QuizAttemptTest.php
@@ -94,31 +94,16 @@ class QuizAttemptTest extends TestCase
             $options = [$question_option_one, $question_option_two, $question_option_three, $question_option_four];
         } else {
             $question = Question::factory()->create([
-                'question' => 'How many layers in OSI model?',
-                'question_type_id' => 1,
-                'is_active' => false,
+                'question' => 'Full Form Of CPU',
+                'question_type_id' => 3,
+                'is_active' => true,
             ]);
             $question_option_one = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => '5',
-                'is_correct' => false,
-            ]);
-            $question_option_two = QuestionOption::factory()->create([
-                'question_id' => $question->id,
-                'option' => '8',
-                'is_correct' => false,
-            ]);
-            $question_option_three = QuestionOption::factory()->create([
-                'question_id' => $question->id,
-                'option' => '10',
-                'is_correct' => false,
-            ]);
-            $question_option_four = QuestionOption::factory()->create([
-                'question_id' => $question->id,
-                'option' => '7',
+                'option' => 'central processing unit',
                 'is_correct' => true,
             ]);
-            $options = [$question_option_one, $question_option_two, $question_option_three, $question_option_four];
+            $options = [$question_option_one];
         }
         $quiz = Quiz::factory()->make()->create([
             'title' => 'Sample Quiz',
@@ -147,66 +132,8 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_1_question_no_negative_marks()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
-            'question_type_id' => 1,
-            'is_active' => false,
-        ]);
-
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '5',
-            'is_correct' => false,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '8',
-            'is_correct' => false,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '10',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '7',
-            'is_correct' => true,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => false,
-                'negative_marking_type' => 'fixed',
-                'negative_mark_value' => 0,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 5,
-            'order' => 1,
-            'negative_marks' => 1,
-        ]);
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(1, false, Quiz::PERCENTAGE_NEGATIVE_TYPE, 0, 5, 0);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
         //Quiz Attempt And Answers
         $quiz_attempt = QuizAttempt::create([
             'quiz_id' => $quiz->id,
@@ -226,72 +153,8 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_1_question_with_negative_marks_question_fixed()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
-            'question_type_id' => 1,
-            'is_active' => false,
-        ]);
-
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '5',
-            'is_correct' => false,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '8',
-            'is_correct' => false,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '10',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '7',
-            'is_correct' => true,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => true,
-                'negative_marking_type' => 'fixed',
-                'negative_mark_value' => 0,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 5,
-            'order' => 1,
-            'negative_marks' => 1,
-        ]);
-        //Quiz Attempt And Answers
-        $quiz_attempt = QuizAttempt::create([
-            'quiz_id' => $quiz->id,
-            'participant_id' => $user->id,
-            'participant_type' => get_class($user)
-        ]);
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(1, true, Quiz::FIXED_NEGATIVE_TYPE, 0, 5, 1);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
         $quiz_attempt_answer = QuizAttemptAnswer::create(
             [
                 'quiz_attempt_id' => $quiz_attempt->id,
@@ -305,72 +168,8 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_1_question_with_negative_marks_question_percentage()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
-            'question_type_id' => 1,
-            'is_active' => false,
-        ]);
-
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '5',
-            'is_correct' => false,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '8',
-            'is_correct' => false,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '10',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '7',
-            'is_correct' => true,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => true,
-                'negative_marking_type' => 'percentage',
-                'negative_mark_value' => 0,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 5,
-            'order' => 1,
-            'negative_marks' => 10,
-        ]);
-        //Quiz Attempt And Answers
-        $quiz_attempt = QuizAttempt::create([
-            'quiz_id' => $quiz->id,
-            'participant_id' => $user->id,
-            'participant_type' => get_class($user)
-        ]);
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(1, true, Quiz::PERCENTAGE_NEGATIVE_TYPE, 0, 5, 10);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
         $quiz_attempt_answer = QuizAttemptAnswer::create(
             [
                 'quiz_attempt_id' => $quiz_attempt->id,
@@ -384,72 +183,9 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_1_question_with_negative_marks_quiz_fixed()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
-            'question_type_id' => 1,
-            'is_active' => false,
-        ]);
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(1, true, Quiz::FIXED_NEGATIVE_TYPE, 2, 10, 0);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
 
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '5',
-            'is_correct' => false,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '8',
-            'is_correct' => false,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '10',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '7',
-            'is_correct' => true,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => true,
-                'negative_marking_type' => 'fixed',
-                'negative_mark_value' => 2,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 10,
-            'order' => 1,
-            'negative_marks' => 0,
-        ]);
-        //Quiz Attempt And Answers
-        $quiz_attempt = QuizAttempt::create([
-            'quiz_id' => $quiz->id,
-            'participant_id' => $user->id,
-            'participant_type' => get_class($user)
-        ]);
         $quiz_attempt_answer = QuizAttemptAnswer::create(
             [
                 'quiz_attempt_id' => $quiz_attempt->id,
@@ -463,72 +199,8 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_1_question_with_negative_marks_quiz_percentage()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
-            'question_type_id' => 1,
-            'is_active' => false,
-        ]);
-
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '5',
-            'is_correct' => false,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '8',
-            'is_correct' => false,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '10',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => '7',
-            'is_correct' => true,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => true,
-                'negative_marking_type' => 'percentage',
-                'negative_mark_value' => 5,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 10,
-            'order' => 1,
-            'negative_marks' => 0,
-        ]);
-        //Quiz Attempt And Answers
-        $quiz_attempt = QuizAttempt::create([
-            'quiz_id' => $quiz->id,
-            'participant_id' => $user->id,
-            'participant_type' => get_class($user)
-        ]);
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(1, true, Quiz::PERCENTAGE_NEGATIVE_TYPE, 5, 10, 0);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
         $quiz_attempt_answer = QuizAttemptAnswer::create(
             [
                 'quiz_attempt_id' => $quiz_attempt->id,
@@ -542,72 +214,9 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_2_question_no_negative_marks()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
-            'question_type_id' => 2,
-            'is_active' => true,
-        ]);
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(2, false, Quiz::PERCENTAGE_NEGATIVE_TYPE, 0, 8, 2);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
 
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'array',
-            'is_correct' => true,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'object',
-            'is_correct' => true,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'for loop',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'method',
-            'is_correct' => false,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => false,
-                'negative_marking_type' => 'fixed',
-                'negative_mark_value' => 0,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 8,
-            'order' => 1,
-            'negative_marks' => 2,
-        ]);
-        //Quiz Attempt And Answers
-        $quiz_attempt = QuizAttempt::create([
-            'quiz_id' => $quiz->id,
-            'participant_id' => $user->id,
-            'participant_type' => get_class($user)
-        ]);
         $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
             [
                 'quiz_attempt_id' => $quiz_attempt->id,
@@ -628,72 +237,11 @@ class QuizAttemptTest extends TestCase
     /** @test */
     function get_score_for_type_2_question_with_negative_marks_question_fixed()
     {
-        $user = Author::create(
-            ['name' => "John Doe"]
-        );
-        //Question Types
-        QuestionType::insert(
-            [
-                [
-                    'question_type' => 'multiple_choice_single_answer',
-                ],
-                [
-                    'question_type' => 'multiple_choice_multiple_answer',
-                ],
-                [
-                    'question_type' => 'fill_the_blank',
-                ]
-            ]
-        );
-        //Question And Options
-        $question = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
-            'question_type_id' => 2,
-            'is_active' => true,
-        ]);
 
-        $question_option_one = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'array',
-            'is_correct' => true,
-        ]);
-        $question_option_two = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'object',
-            'is_correct' => true,
-        ]);
-        $question_option_three = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'for loop',
-            'is_correct' => false,
-        ]);
-        $question_option_four = QuestionOption::factory()->create([
-            'question_id' => $question->id,
-            'option' => 'method',
-            'is_correct' => false,
-        ]);
-        $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
-            'slug' => 'sample-quiz',
-            'negative_marking_settings' => [
-                'enable_negative_marks' => true,
-                'negative_marking_type' => 'fixed',
-                'negative_mark_value' => 0,
-            ]
-        ]);
-        $quiz_question =  QuizQuestion::factory()->create([
-            'quiz_id' => $quiz->id,
-            'question_id' => $question->id,
-            'marks' => 8,
-            'order' => 1,
-            'negative_marks' => 2,
-        ]);
-        //Quiz Attempt And Answers
-        $quiz_attempt = QuizAttempt::create([
-            'quiz_id' => $quiz->id,
-            'participant_id' => $user->id,
-            'participant_type' => get_class($user)
-        ]);
+
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(2, true, Quiz::FIXED_NEGATIVE_TYPE, 0, 8, 2);
+        [$question_option_one, $question_option_two, $question_option_three, $question_option_four] = $options;
+
         $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
             [
                 'quiz_attempt_id' => $quiz_attempt->id,
@@ -701,13 +249,6 @@ class QuizAttemptTest extends TestCase
                 'question_option_id' => $question_option_one->id,
             ]
         );
-        // $quiz_attempt_answer_two = QuizAttemptAnswer::create(
-        //     [
-        //         'quiz_attempt_id' => $quiz_attempt->id,
-        //         'quiz_question_id' => $quiz_question->id,
-        //         'question_option_id' => $question_option_two->id,
-        //     ]
-        // );
         $this->assertEquals(-2, QuizAttempt::get_score_for_type_2_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
     }
 
@@ -757,5 +298,163 @@ class QuizAttemptTest extends TestCase
             ]
         );
         $this->assertEquals(-0.5, QuizAttempt::get_score_for_type_2_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+
+    /** @test */
+    function get_score_for_type_3_question_no_negative_marks()
+    {
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(3, false, Quiz::PERCENTAGE_NEGATIVE_TYPE, 0, 5, 0);
+        [$question_option_one] = $options;
+
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+                'answer' => 'central processing unit'
+            ]
+        );
+        $this->assertEquals(5, QuizAttempt::get_score_for_type_3_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+
+    /** @test */
+    function get_score_for_type_3_question_with_negative_marks_question_fixed()
+    {
+
+
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(3, true, Quiz::FIXED_NEGATIVE_TYPE, 0, 5, 1);
+        [$question_option_one] = $options;
+
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+                'answer' => 'cpu'
+            ]
+        );
+        $this->assertEquals(-1, QuizAttempt::get_score_for_type_3_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+
+    /** @test */
+    function get_score_for_type_3_question_with_negative_marks_question_percentage()
+    {
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(3, true, Quiz::PERCENTAGE_NEGATIVE_TYPE, 0, 10, 10);
+        [$question_option_one] = $options;
+
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+                'answer' => 'cpu'
+            ]
+        );
+        $this->assertEquals(-1, QuizAttempt::get_score_for_type_3_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+
+    /** @test */
+    function get_score_for_type_3_question_with_negative_marks_quiz_fixed()
+    {
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(3, true, Quiz::FIXED_NEGATIVE_TYPE, 1, 5, 0);
+        [$question_option_one] = $options;
+
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+                'answer' => 'cpu'
+            ]
+        );
+        $this->assertEquals(-1, QuizAttempt::get_score_for_type_3_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+
+    /** @test */
+    function get_score_for_type_3_question_with_negative_marks_quiz_percentage()
+    {
+        [$user, $question, $options, $quiz, $quiz_question, $quiz_attempt] = $this->init(3, true, Quiz::PERCENTAGE_NEGATIVE_TYPE, 10, 5, 0);
+        [$question_option_one] = $options;
+
+        $quiz_attempt_answer_one =  QuizAttemptAnswer::create(
+            [
+                'quiz_attempt_id' => $quiz_attempt->id,
+                'quiz_question_id' => $quiz_question->id,
+                'question_option_id' => $question_option_one->id,
+                'answer' => 'cpu'
+            ]
+        );
+        $this->assertEquals(-0.5, QuizAttempt::get_score_for_type_3_question($quiz_attempt, $quiz_question, [$quiz_attempt_answer_one]));
+    }
+
+    /** @test */
+    function get_negative_marks_for_question()
+    {
+        $testCases = [
+            [
+                'enable_negative_marks' => false,
+                'quiz_negative_marks_type' => Quiz::FIXED_NEGATIVE_TYPE,
+                'quiz_negative_marks' => 0,
+                'question_marks' => 5,
+                'question_negative_marks' => 0,
+                'expected_negative_marks' => 0
+            ],
+            [
+                'enable_negative_marks' => true,
+                'quiz_negative_marks_type' => Quiz::FIXED_NEGATIVE_TYPE,
+                'quiz_negative_marks' => 0,
+                'question_marks' => 5,
+                'question_negative_marks' => 1,
+                'expected_negative_marks' => 1
+            ],
+            [
+                'enable_negative_marks' => true,
+                'quiz_negative_marks_type' => Quiz::PERCENTAGE_NEGATIVE_TYPE,
+                'quiz_negative_marks' => 0,
+                'question_marks' => 5,
+                'question_negative_marks' => 30,
+                'expected_negative_marks' => 1.5
+            ],
+            [
+                'enable_negative_marks' => true,
+                'quiz_negative_marks_type' => Quiz::FIXED_NEGATIVE_TYPE,
+                'quiz_negative_marks' => 1,
+                'question_marks' => 5,
+                'question_negative_marks' => 0,
+                'expected_negative_marks' => 1
+            ],
+            [
+                'enable_negative_marks' => true,
+                'quiz_negative_marks_type' => Quiz::PERCENTAGE_NEGATIVE_TYPE,
+                'quiz_negative_marks' => 40,
+                'question_marks' => 5,
+                'question_negative_marks' => 0,
+                'expected_negative_marks' => 2
+            ]
+        ];
+        $question = Question::factory()->create([
+            'question' => 'Full Form Of CPU',
+            'question_type_id' => 3,
+            'is_active' => true,
+        ]);
+        foreach ($testCases as $key => $testCase) {
+            $quiz = Quiz::factory()->make()->create([
+                'title' => 'Sample Quiz',
+                'slug' => 'sample-quiz-' . $key,
+                'negative_marking_settings' => [
+                    'enable_negative_marks' => $testCase['enable_negative_marks'],
+                    'negative_marking_type' => $testCase['quiz_negative_marks_type'],
+                    'negative_mark_value' => $testCase['quiz_negative_marks'],
+                ]
+            ]);
+            $quizQuestion =  QuizQuestion::factory()->create([
+                'quiz_id' => $quiz->id,
+                'question_id' => $question->id,
+                'marks' => $testCase['question_marks'],
+                'order' => 1,
+                'negative_marks' => $testCase['question_negative_marks'],
+            ]);
+            $this->assertEquals($testCase['expected_negative_marks'], QuizAttempt::get_negative_marks_for_question($quiz, $quizQuestion));
+        }
     }
 }

--- a/tests/Unit/QuizTest.php
+++ b/tests/Unit/QuizTest.php
@@ -202,7 +202,7 @@ class QuizTest extends TestCase
             'valid_upto' => null,
         ]);
         $quizTwo = Quiz::find($quizTwo->id);
-        $this->assertEquals(false, $quizTwo->negative_marking_settings['enable_negative_marks']);
+        $this->assertEquals(true, $quizTwo->negative_marking_settings['enable_negative_marks']);
         $quizThree = Quiz::factory()->make()->create([
             'title' => 'Sample Quiz',
             'slug' => 'sample-quiz-3',

--- a/tests/Unit/QuizTest.php
+++ b/tests/Unit/QuizTest.php
@@ -172,4 +172,55 @@ class QuizTest extends TestCase
         $this->assertEquals(1, $question_one->options()->first()->answers()->count());
         $this->assertEquals(1, $question_two->options()->first()->answers()->count());
     }
+
+    /** @test */
+    function quiz_check_negative_marking_settings()
+    {
+        $quizOne = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => false,
+                'negative_marking_type' => 'fixed',
+                'negative_mark_value' => 0,
+            ]
+        ]);
+        $this->assertEquals(false, $quizOne->negative_marking_settings['enable_negative_marks']);
+        $quizTwo = Quiz::create([
+            'title' => "Sample Quiz",
+            'slug' => "sample-quiz-two",
+            'description' => "",
+            'media_url' => null,
+            'total_marks' => 0,
+            'pass_marks' => 0,
+            'max_attempts' => 0,
+            'is_published' => 1,
+            'media_url' => null,
+            'media_type' => 'image',
+            'duration' => 0,
+            'valid_from' => date('Y-m-d H:i:s'),
+            'valid_upto' => null,
+        ]);
+        $quizTwo = Quiz::find($quizTwo->id);
+        $this->assertEquals(false, $quizTwo->negative_marking_settings['enable_negative_marks']);
+        $quizThree = Quiz::factory()->make()->create([
+            'title' => 'Sample Quiz',
+            'slug' => 'sample-quiz-3',
+            'negative_marking_settings' => [
+                'enable_negative_marks' => true,
+                'negative_marking_type' => 'percentage',
+                'negative_mark_value' => 10,
+            ]
+        ]);
+        $this->assertEquals(true, $quizThree->negative_marking_settings['enable_negative_marks']);
+        $this->assertEquals('percentage', $quizThree->negative_marking_settings['negative_marking_type']);
+        $this->assertEquals(10, $quizThree->negative_marking_settings['negative_mark_value']);
+        $quizThree->negative_marking_settings = [
+            'enable_negative_marks' => true,
+            'negative_marking_type' => 'percentage',
+            'negative_mark_value' => 23,
+        ];
+        $quizThree->save();
+        $this->assertEquals(23, $quizThree->negative_marking_settings['negative_mark_value']);
+    }
 }


### PR DESCRIPTION
### Change Log:
- New JSON field `negative_marking_settings` added to quizzes table to store negative marking settings. Properties are `enable_negative_marks`:Boolean, `negative_marking_type`:(fixed,percentage),`negative_mark_value`:any valid number >= zero.
- User-defined custom methods to evaluate a custom question type can be configured from the configuration file.
- 4 Static Methods added to QuizAttempt model: `get_score_for_type_1_question`,` get_score_for_type_2_question`, `get_score_for_type_3_question`, `get_negative_marks_for_question`.
- New migration file to add `negative_marking_settings` JSON column to new and existing tables.
- Test cases were added to test the newly added methods and settings.