### PR TITLE
Negative marks method updated to handle negative number scenario. Readme updated.

### DIFF
--- a/src/Models/QuizAttempt.php
+++ b/src/Models/QuizAttempt.php
@@ -127,9 +127,10 @@ class QuizAttempt extends Model
             return 0;
         }
         if (!empty($quizQuestion->negative_marks)) {
-            return $negative_marking_settings['negative_marking_type'] == 'fixed' ? $quizQuestion->negative_marks : ($quizQuestion->marks * ($quizQuestion->negative_marks / 100));
+            return $negative_marking_settings['negative_marking_type'] == 'fixed' ?
+                ($quizQuestion->negative_marks < 0 ? -$quizQuestion->negative_marks : $quizQuestion->negative_marks) : ($quizQuestion->marks * (($quizQuestion->negative_marks < 0 ? -$quizQuestion->negative_marks : $quizQuestion->negative_marks) / 100));
         } else {
-            return $negative_marking_settings['negative_marking_type'] == 'fixed' ? $negative_marking_settings['negative_mark_value'] : ($quizQuestion->marks * ($negative_marking_settings['negative_mark_value'] / 100));
+            return $negative_marking_settings['negative_marking_type'] == 'fixed' ? ($negative_marking_settings['negative_mark_value'] < 0 ? -$negative_marking_settings['negative_mark_value'] : $negative_marking_settings['negative_mark_value']) : ($quizQuestion->marks * (($negative_marking_settings['negative_mark_value'] < 0 ? -$negative_marking_settings['negative_mark_value'] : $negative_marking_settings['negative_mark_value']) / 100));
         }
     }
 }


### PR DESCRIPTION
- Class diagram was corrected.
- Readme updated with the latest details about user-defined methods to evaluate answers and return scores and negative marking settings.
- `get_negative_marks_for_question` method fixed to handle when users set negative marks with negative numbers.