### PR TITLE
Rename table field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.0.2",
+        "doctrine/dbal": "^3.3",
         "illuminate/support": "^9.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec138edf7cc63ab9c9c1ae51cc2a48aa",
+    "content-hash": "e1405c383f6b640c29e4605409ed6dde",
     "packages": [
         {
             "name": "brick/math",
@@ -140,6 +140,347 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
             },
             "time": "2021-08-13T13:06:58+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T20:07:39+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "9e7f76dd1cde81c62574fdffa5a9c655c847ad21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9e7f76dd1cde81c62574fdffa5a9c655c847ad21",
+                "reference": "9e7f76dd1cde81c62574fdffa5a9c655c847ad21",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "9.0.0",
+                "jetbrains/phpstorm-stubs": "2022.1",
+                "phpstan/phpstan": "1.6.3",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "9.5.20",
+                "psalm/plugin-phpunit": "0.16.1",
+                "squizlabs/php_codesniffer": "3.6.2",
+                "symfony/cache": "^5.2|^6.0",
+                "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0",
+                "vimeo/psalm": "4.23.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-02T17:21:01+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5|^8.5|^9.5",
+                "psr/log": "^1|^2|^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+            },
+            "time": "2022-05-02T15:47:09+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T18:28:51+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1560,6 +1901,55 @@
                 }
             ],
             "time": "2021-12-04T23:24:31+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/container",
@@ -7927,5 +8317,5 @@
         "php": ">=8.0.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -15,11 +15,11 @@ class QuestionFactory extends Factory
     {
         $question_type = QuestionType::create(
             [
-                'question_type' => 'fill_the_blank',
+                'name' => 'fill_the_blank',
             ]
         );
         return [
-            'question' => $this->faker->words(4, true),
+            'name' => $this->faker->words(4, true),
             'question_type_id' => $question_type->id,
             'media_url' => $this->faker->url,
             'is_active' => $this->faker->numberBetween(0, 1),

--- a/database/factories/QuestionOptionFactory.php
+++ b/database/factories/QuestionOptionFactory.php
@@ -13,7 +13,7 @@ class QuestionOptionFactory extends Factory
     {
         return [
             'question_id' => null,
-            'option' => $this->faker->word,
+            'name' => $this->faker->word,
             'media_url' => $this->faker->url,
             'is_correct' => $this->faker->numberBetween(0, 1),
             'media_type' => 'image',

--- a/database/factories/QuestionTypeFactory.php
+++ b/database/factories/QuestionTypeFactory.php
@@ -13,7 +13,7 @@ class QuestionTypeFactory extends Factory
     public function definition()
     {
         return [
-            'question_type' => $this->faker->words(1, true)
+            'name' => $this->faker->words(1, true)
         ];
     }
 }

--- a/database/factories/QuizFactory.php
+++ b/database/factories/QuizFactory.php
@@ -12,11 +12,11 @@ class QuizFactory extends Factory
 
     public function definition()
     {
-        $title = $this->faker->title;
+        $name = $this->faker->name;
 
         return [
-            'title' => $title,
-            'slug' => Str::slug($title),
+            'name' => $name,
+            'slug' => Str::slug($name),
             'description' => $this->faker->paragraph,
             'total_marks' => 0,
             'pass_marks' => 0,

--- a/database/factories/TopicFactory.php
+++ b/database/factories/TopicFactory.php
@@ -12,10 +12,10 @@ class TopicFactory extends Factory
 
     public function definition()
     {
-        $topic = $this->faker->words(4, true);
+        $name = $this->faker->words(4, true);
         return [
-            'topic' => $topic,
-            'slug' => Str::slug($topic, '-'),
+            'name' => $name,
+            'slug' => Str::slug($name, '-'),
             'parent_id' => null,
             'is_active' => $this->faker->numberBetween(0, 1)
         ];

--- a/database/migrations/2022_06_09_203138_rename_quizzes_tables.php
+++ b/database/migrations/2022_06_09_203138_rename_quizzes_tables.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public array $tableNames;
+    public function __construct()
+    {
+        $this->tableNames = config('laravel-quiz.table_names');
+    }
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table($this->tableNames['topics'], function (Blueprint $table) {
+            $table->renameColumn('topic', 'name');
+        });
+        Schema::table($this->tableNames['question_types'], function (Blueprint $table) {
+            $table->renameColumn('question_type', 'name');
+        });
+        Schema::table($this->tableNames['questions'], function (Blueprint $table) {
+            $table->renameColumn('question', 'name');
+        });
+        Schema::table($this->tableNames['question_options'], function (Blueprint $table) {
+            $table->renameColumn('option', 'name');
+        });
+        Schema::table($this->tableNames['quizzes'], function (Blueprint $table) {
+            $table->renameColumn('title', 'name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table($this->tableNames['topics'], function (Blueprint $table) {
+            $table->renameColumn('name', 'topic');
+        });
+        Schema::table($this->tableNames['question_types'], function (Blueprint $table) {
+            $table->renameColumn('name', 'question_type');
+        });
+        Schema::table($this->tableNames['questions'], function (Blueprint $table) {
+            $table->renameColumn('name', 'question');
+        });
+        Schema::table($this->tableNames['question_options'], function (Blueprint $table) {
+            $table->renameColumn('name', 'option');
+        });
+        Schema::table($this->tableNames['quizzes'], function (Blueprint $table) {
+            $table->renameColumn('name', 'title');
+        });
+    }
+};

--- a/database/seeders/QuestionTypeSeeder.php
+++ b/database/seeders/QuestionTypeSeeder.php
@@ -17,13 +17,13 @@ class QuestionTypeSeeder extends Seeder
         QuestionType::create(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );

--- a/src/Models/Question.php
+++ b/src/Models/Question.php
@@ -3,6 +3,7 @@
 namespace Harishdurga\LaravelQuiz\Models;
 
 use Harishdurga\LaravelQuiz\Database\Factories\QuestionFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -24,9 +25,18 @@ class Question extends Model
         return config('laravel-quiz.table_names.questions');
     }
 
-    protected static function newFactory()
+    /**
+     * Backward compatibility of the attribute
+     *
+     * @param  string  $value
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    protected function question(): Attribute
     {
-        return QuestionFactory::new();
+        return new Attribute(
+            get: fn ($value, $attributes) => $attributes['name'],
+            set: fn ($value) => ['name' => $value],
+        );
     }
 
     public function question_type()
@@ -47,6 +57,11 @@ class Question extends Model
     public function quiz_questions()
     {
         return $this->hasMany(QuizQuestion::class);
+    }
+
+    protected static function newFactory()
+    {
+        return QuestionFactory::new();
     }
 
     public function correct_options(): Collection

--- a/src/Models/QuestionOption.php
+++ b/src/Models/QuestionOption.php
@@ -3,6 +3,7 @@
 namespace Harishdurga\LaravelQuiz\Models;
 
 use Harishdurga\LaravelQuiz\Database\Factories\QuestionOptionFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -23,18 +24,32 @@ class QuestionOption extends Model
         return config('laravel-quiz.table_names.question_options');
     }
 
+    /**
+     * Backward compatibility of the attribute
+     *
+     * @param  string  $value
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    protected function option(): Attribute
+    {
+        return new Attribute(
+            get: fn ($value, $attributes) => $attributes['name'],
+            set: fn ($value) => ['name' => $value],
+        );
+    }
+
     public function question()
     {
         return $this->belongsTo(Question::class);
     }
 
-    protected static function newFactory()
-    {
-        return QuestionOptionFactory::new();
-    }
-
     public function answers()
     {
         return $this->hasMany(QuizAttemptAnswer::class);
+    }
+
+    protected static function newFactory()
+    {
+        return QuestionOptionFactory::new();
     }
 }

--- a/src/Models/QuestionType.php
+++ b/src/Models/QuestionType.php
@@ -3,6 +3,7 @@
 namespace Harishdurga\LaravelQuiz\Models;
 
 use Harishdurga\LaravelQuiz\Database\Factories\QuestionTypeFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -21,6 +22,20 @@ class QuestionType extends Model
     public function getTable()
     {
         return config('laravel-quiz.table_names.question_types');
+    }
+
+    /**
+     * Backward compatibility of the attribute
+     *
+     * @param  string  $value
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    protected function question_type(): Attribute
+    {
+        return new Attribute(
+            get: fn ($value, $attributes) => $attributes['name'],
+            set: fn ($value) => ['name' => $value],
+        );
     }
 
     public function questions()

--- a/src/Models/Quiz.php
+++ b/src/Models/Quiz.php
@@ -36,14 +36,23 @@ class Quiz extends Model
         return config('laravel-quiz.table_names.quizzes');
     }
 
+    /**
+     * Backward compatibility of the attribute
+     *
+     * @param  string  $value
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    protected function title(): Attribute
+    {
+        return new Attribute(
+            get: fn ($value, $attributes) => $attributes['name'],
+            set: fn ($value) => ['name' => $value],
+        );
+    }
+
     public function topics()
     {
         return $this->morphToMany(Topic::class, 'topicable');
-    }
-
-    public static function newFactory()
-    {
-        return QuizFactory::new();
     }
 
     public function questions()
@@ -54,6 +63,11 @@ class Quiz extends Model
     public function attempts()
     {
         return $this->hasMany(QuizAttempt::class);
+    }
+
+    public static function newFactory()
+    {
+        return QuizFactory::new();
     }
 
     /**

--- a/src/Models/QuizQuestion.php
+++ b/src/Models/QuizQuestion.php
@@ -23,11 +23,6 @@ class QuizQuestion extends Model
         return config('laravel-quiz.table_names.quiz_questions');
     }
 
-    protected static function newFactory()
-    {
-        return new QuizQuestionFactory();
-    }
-
     public function quiz()
     {
         return $this->belongsTo(Quiz::class);
@@ -41,5 +36,10 @@ class QuizQuestion extends Model
     public function answers()
     {
         return $this->hasMany(QuizAttemptAnswer::class);
+    }
+
+    protected static function newFactory()
+    {
+        return new QuizQuestionFactory();
     }
 }

--- a/src/Models/Topic.php
+++ b/src/Models/Topic.php
@@ -3,6 +3,7 @@
 namespace Harishdurga\LaravelQuiz\Models;
 
 use Harishdurga\LaravelQuiz\Database\Factories\TopicFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -18,14 +19,23 @@ class Topic extends Model
      */
     protected $guarded = ['id'];
 
-    protected static function newFactory()
-    {
-        return TopicFactory::new();
-    }
-
     public function getTable()
     {
         return config('laravel-quiz.table_names.topics', parent::getTable());
+    }
+
+    /**
+     * Backward compatibility of the attribute
+     *
+     * @param  string  $value
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    protected function topic(): Attribute
+    {
+        return new Attribute(
+            get: fn ($value, $attributes) => $attributes['name'],
+            set: fn ($value) => ['name' => $value],
+        );
     }
 
     public function children()
@@ -46,5 +56,10 @@ class Topic extends Model
     public function quizzes()
     {
         return $this->morphedByMany(Quiz::class, 'topicable');
+    }
+
+    protected static function newFactory()
+    {
+        return TopicFactory::new();
     }
 }

--- a/tests/Feature/QuizTest.php
+++ b/tests/Feature/QuizTest.php
@@ -22,19 +22,19 @@ class QuizTest extends TestCase
     function quiz_multiple_choice_single_answer_all_correct_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -46,41 +46,41 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'What is an algorithm?',
+            'name' => 'What is an algorithm?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A computer program that solves a problem.',
+            'name' => 'A computer program that solves a problem.',
             'is_correct' => false,
         ]);
         $question_one_option_two = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of rules that define the behavior of a computer program.',
+            'name' => 'A set of rules that define the behavior of a computer program.',
             'is_correct' => false,
         ]);
         $question_one_option_three = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of instructions that tell a computer what to do.',
+            'name' => 'A set of instructions that tell a computer what to do.',
             'is_correct' => true,
         ]);
         $question_one_option_four = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'None of the above.',
+            'name' => 'None of the above.',
             'is_correct' => false,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
@@ -89,29 +89,29 @@ class QuizTest extends TestCase
 
         // Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'if',
+            'name' => 'if',
             'is_correct' => false,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'for loop',
+            'name' => 'for loop',
             'is_correct' => false,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
@@ -120,29 +120,29 @@ class QuizTest extends TestCase
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
@@ -153,7 +153,7 @@ class QuizTest extends TestCase
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,
@@ -234,19 +234,19 @@ class QuizTest extends TestCase
     function quiz_multiple_choice_single_answer_few_worng_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -258,41 +258,41 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'What is an algorithm?',
+            'name' => 'What is an algorithm?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A computer program that solves a problem.',
+            'name' => 'A computer program that solves a problem.',
             'is_correct' => false,
         ]);
         $question_one_option_two = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of rules that define the behavior of a computer program.',
+            'name' => 'A set of rules that define the behavior of a computer program.',
             'is_correct' => false,
         ]);
         $question_one_option_three = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of instructions that tell a computer what to do.',
+            'name' => 'A set of instructions that tell a computer what to do.',
             'is_correct' => true,
         ]);
         $question_one_option_four = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'None of the above.',
+            'name' => 'None of the above.',
             'is_correct' => false,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
@@ -301,29 +301,29 @@ class QuizTest extends TestCase
 
         // Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'if',
+            'name' => 'if',
             'is_correct' => false,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'for loop',
+            'name' => 'for loop',
             'is_correct' => false,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
@@ -332,29 +332,29 @@ class QuizTest extends TestCase
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
@@ -365,7 +365,7 @@ class QuizTest extends TestCase
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,
@@ -447,19 +447,19 @@ class QuizTest extends TestCase
     function quiz_multiple_choice_multiple_answer_all_correct_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -471,41 +471,41 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'What is an algorithm?',
+            'name' => 'What is an algorithm?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A computer program that solves a problem.',
+            'name' => 'A computer program that solves a problem.',
             'is_correct' => false,
         ]);
         $question_one_option_two = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of rules that define the behavior of a computer program.',
+            'name' => 'A set of rules that define the behavior of a computer program.',
             'is_correct' => false,
         ]);
         $question_one_option_three = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of instructions that tell a computer what to do.',
+            'name' => 'A set of instructions that tell a computer what to do.',
             'is_correct' => true,
         ]);
         $question_one_option_four = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'None of the above.',
+            'name' => 'None of the above.',
             'is_correct' => false,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
@@ -514,29 +514,29 @@ class QuizTest extends TestCase
 
         // Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'string',
+            'name' => 'string',
             'is_correct' => true,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'object',
+            'name' => 'object',
             'is_correct' => true,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
@@ -545,29 +545,29 @@ class QuizTest extends TestCase
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
@@ -578,7 +578,7 @@ class QuizTest extends TestCase
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,
@@ -671,19 +671,19 @@ class QuizTest extends TestCase
     function quiz_multiple_choice_multiple_answer_all_few_wrong_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -695,41 +695,41 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'What is an algorithm?',
+            'name' => 'What is an algorithm?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A computer program that solves a problem.',
+            'name' => 'A computer program that solves a problem.',
             'is_correct' => false,
         ]);
         $question_one_option_two = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of rules that define the behavior of a computer program.',
+            'name' => 'A set of rules that define the behavior of a computer program.',
             'is_correct' => false,
         ]);
         $question_one_option_three = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'A set of instructions that tell a computer what to do.',
+            'name' => 'A set of instructions that tell a computer what to do.',
             'is_correct' => true,
         ]);
         $question_one_option_four = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'None of the above.',
+            'name' => 'None of the above.',
             'is_correct' => false,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
@@ -738,29 +738,29 @@ class QuizTest extends TestCase
 
         // Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 2,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'string',
+            'name' => 'string',
             'is_correct' => true,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'object',
+            'name' => 'object',
             'is_correct' => true,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
@@ -769,29 +769,29 @@ class QuizTest extends TestCase
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
@@ -802,7 +802,7 @@ class QuizTest extends TestCase
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,
@@ -896,19 +896,19 @@ class QuizTest extends TestCase
     function quiz_fill_the_blank_all_correct_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -920,26 +920,26 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'Full Form Of CPU',
+            'name' => 'Full Form Of CPU',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'central processing unit',
+            'name' => 'central processing unit',
             'is_correct' => true,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
@@ -948,29 +948,29 @@ class QuizTest extends TestCase
 
         // Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'if',
+            'name' => 'if',
             'is_correct' => false,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'for loop',
+            'name' => 'for loop',
             'is_correct' => false,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
@@ -979,29 +979,29 @@ class QuizTest extends TestCase
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
@@ -1011,7 +1011,7 @@ class QuizTest extends TestCase
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,
@@ -1093,19 +1093,19 @@ class QuizTest extends TestCase
     function quiz_fill_the_blank_few_wrong_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -1117,26 +1117,26 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'Full Form Of CPU',
+            'name' => 'Full Form Of CPU',
             'question_type_id' => 3,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'central processing unit',
+            'name' => 'central processing unit',
             'is_correct' => true,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
@@ -1145,29 +1145,29 @@ class QuizTest extends TestCase
 
         //Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 1,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'if',
+            'name' => 'if',
             'is_correct' => false,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'for loop',
+            'name' => 'for loop',
             'is_correct' => false,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
@@ -1176,29 +1176,29 @@ class QuizTest extends TestCase
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
@@ -1208,7 +1208,7 @@ class QuizTest extends TestCase
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,
@@ -1290,19 +1290,19 @@ class QuizTest extends TestCase
     function quiz_multi_user_attempts_multi_question_types_few_wrong_answers()
     {
         $computer_science = Topic::factory()->create([
-            'topic' => 'Computer Science',
+            'name' => 'Computer Science',
             'slug' => 'computer-science',
         ]);
         $algorithms = Topic::factory()->create([
-            'topic' => 'Algorithms',
+            'name' => 'Algorithms',
             'slug' => 'algorithms'
         ]);
         $data_structures = Topic::factory()->create([
-            'topic' => 'Data Structures',
+            'name' => 'Data Structures',
             'slug' => 'data-structures'
         ]);
         $computer_networks = Topic::factory()->create([
-            'topic' => 'Computer Networks',
+            'name' => 'Computer Networks',
             'slug' => 'computer-networks'
         ]);
         $computer_science->children()->save($algorithms);
@@ -1313,91 +1313,91 @@ class QuizTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
 
         // Question One And Options
         $question_one = Question::factory()->create([
-            'question' => 'Full Form Of CPU',
+            'name' => 'Full Form Of CPU',
             'question_type_id' => 3,
             'is_active' => true,
         ]);
         $question_one_option_one = QuestionOption::factory()->create([
             'question_id' => $question_one->id,
-            'option' => 'central processing unit',
+            'name' => 'central processing unit',
             'is_correct' => true,
         ]);
         $question_one->topics()->attach([$computer_science->id, $algorithms->id]);
 
         // Question Two And Options
         $question_two = Question::factory()->create([
-            'question' => 'Which of the below is a data structure?',
+            'name' => 'Which of the below is a data structure?',
             'question_type_id' => 2,
             'is_active' => true,
         ]);
 
         $question_two_option_one = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'array',
+            'name' => 'array',
             'is_correct' => true,
         ]);
         $question_two_option_two = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'object',
+            'name' => 'object',
             'is_correct' => true,
         ]);
         $question_two_option_three = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'for loop',
+            'name' => 'for loop',
             'is_correct' => false,
         ]);
         $question_two_option_four = QuestionOption::factory()->create([
             'question_id' => $question_two->id,
-            'option' => 'method',
+            'name' => 'method',
             'is_correct' => false,
         ]);
         $question_two->topics()->attach([$computer_science->id, $data_structures->id]);
 
         // Question Three And Options
         $question_three = Question::factory()->create([
-            'question' => 'How many layers in OSI model?',
+            'name' => 'How many layers in OSI model?',
             'question_type_id' => 1,
             'is_active' => false,
         ]);
 
         $question_three_option_one = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '5',
+            'name' => '5',
             'is_correct' => false,
         ]);
         $question_three_option_two = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '8',
+            'name' => '8',
             'is_correct' => false,
         ]);
         $question_three_option_three = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '10',
+            'name' => '10',
             'is_correct' => false,
         ]);
         $question_three_option_four = QuestionOption::factory()->create([
             'question_id' => $question_three->id,
-            'option' => '7',
+            'name' => '7',
             'is_correct' => true,
         ]);
         $question_three->topics()->attach([$computer_science->id, $computer_networks->id]);
 
         // Quiz
         $quiz = Quiz::factory()->create([
-            'title' => 'Computer Sceince Quiz',
+            'name' => 'Computer Sceince Quiz',
             'description' => 'Test your knowledge of computer science',
             'slug' => 'computer-science-quiz',
             'total_marks' => 10,

--- a/tests/Unit/QuestionTest.php
+++ b/tests/Unit/QuestionTest.php
@@ -24,7 +24,7 @@ class QuestionTest extends TestCase
     function question_question_type_relation()
     {
         $questionType = QuestionType::factory()->create([
-            'question_type' => 'fill_the_blank'
+            'name' => 'fill_the_blank'
         ]);
         $questionType->questions()->saveMany([
             Question::factory()->make(),

--- a/tests/Unit/QuizAttemptTest.php
+++ b/tests/Unit/QuizAttemptTest.php
@@ -28,85 +28,85 @@ class QuizAttemptTest extends TestCase
         QuestionType::insert(
             [
                 [
-                    'question_type' => 'multiple_choice_single_answer',
+                    'name' => 'multiple_choice_single_answer',
                 ],
                 [
-                    'question_type' => 'multiple_choice_multiple_answer',
+                    'name' => 'multiple_choice_multiple_answer',
                 ],
                 [
-                    'question_type' => 'fill_the_blank',
+                    'name' => 'fill_the_blank',
                 ]
             ]
         );
         if ($questionType == 1) {
             $question = Question::factory()->create([
-                'question' => 'How many layers in OSI model?',
+                'name' => 'How many layers in OSI model?',
                 'question_type_id' => 1,
                 'is_active' => false,
             ]);
             $question_option_one = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => '5',
+                'name' => '5',
                 'is_correct' => false,
             ]);
             $question_option_two = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => '8',
+                'name' => '8',
                 'is_correct' => false,
             ]);
             $question_option_three = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => '10',
+                'name' => '10',
                 'is_correct' => false,
             ]);
             $question_option_four = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => '7',
+                'name' => '7',
                 'is_correct' => true,
             ]);
             $options = [$question_option_one, $question_option_two, $question_option_three, $question_option_four];
         } elseif ($questionType == 2) {
             $question = Question::factory()->create([
-                'question' => 'Which of the below is a data structure?',
+                'name' => 'Which of the below is a data structure?',
                 'question_type_id' => 2,
                 'is_active' => true,
             ]);
             $question_option_one = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => 'array',
+                'name' => 'array',
                 'is_correct' => true,
             ]);
             $question_option_two = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => 'object',
+                'name' => 'object',
                 'is_correct' => true,
             ]);
             $question_option_three = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => 'for loop',
+                'name' => 'for loop',
                 'is_correct' => false,
             ]);
             $question_option_four = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => 'method',
+                'name' => 'method',
                 'is_correct' => false,
             ]);
             $options = [$question_option_one, $question_option_two, $question_option_three, $question_option_four];
         } else {
             $question = Question::factory()->create([
-                'question' => 'Full Form Of CPU',
+                'name' => 'Full Form Of CPU',
                 'question_type_id' => 3,
                 'is_active' => true,
             ]);
             $question_option_one = QuestionOption::factory()->create([
                 'question_id' => $question->id,
-                'option' => 'central processing unit',
+                'name' => 'central processing unit',
                 'is_correct' => true,
             ]);
             $options = [$question_option_one];
         }
         $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
             'negative_marking_settings' => [
                 'enable_negative_marks' => $enableNegativeMarks,
@@ -433,13 +433,13 @@ class QuizAttemptTest extends TestCase
             ]
         ];
         $question = Question::factory()->create([
-            'question' => 'Full Form Of CPU',
+            'name' => 'Full Form Of CPU',
             'question_type_id' => 3,
             'is_active' => true,
         ]);
         foreach ($testCases as $key => $testCase) {
             $quiz = Quiz::factory()->make()->create([
-                'title' => 'Sample Quiz',
+                'name' => 'Sample Quiz',
                 'slug' => 'sample-quiz-' . $key,
                 'negative_marking_settings' => [
                     'enable_negative_marks' => $testCase['enable_negative_marks'],

--- a/tests/Unit/QuizTest.php
+++ b/tests/Unit/QuizTest.php
@@ -21,26 +21,26 @@ class QuizTest extends TestCase
     function quiz()
     {
         $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
         ]);
         $this->assertEquals(1, Quiz::count());
-        $this->assertEquals('Sample Quiz', Quiz::find($quiz->id)->title);
+        $this->assertEquals('Sample Quiz', Quiz::find($quiz->id)->name);
     }
 
     /** @test */
     function quiz_topics_relation()
     {
         $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
         ]);
         $topic_one = Topic::factory()->make()->create([
-            'topic' => 'Topic One',
+            'name' => 'Topic One',
             'slug' => 'topic-one',
         ]);
         $topic_two = Topic::factory()->make()->create([
-            'topic' => 'Topic Two',
+            'name' => 'Topic Two',
             'slug' => 'topic-two',
         ]);
         $quiz->topics()->attach([$topic_one->id, $topic_two->id]);
@@ -51,7 +51,7 @@ class QuizTest extends TestCase
     function quiz_questions_relation()
     {
         $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
         ]);
         $question_one = Question::factory()->create();
@@ -77,7 +77,7 @@ class QuizTest extends TestCase
             ['name' => "John Doe"]
         );
         $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
         ]);
         $question_one = Question::factory()->create();
@@ -121,7 +121,7 @@ class QuizTest extends TestCase
             ['name' => "John Doe"]
         );
         $quiz = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
         ]);
         $question_one = Question::factory()->create();
@@ -177,7 +177,7 @@ class QuizTest extends TestCase
     function quiz_check_negative_marking_settings()
     {
         $quizOne = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz',
             'negative_marking_settings' => [
                 'enable_negative_marks' => false,
@@ -187,7 +187,7 @@ class QuizTest extends TestCase
         ]);
         $this->assertEquals(false, $quizOne->negative_marking_settings['enable_negative_marks']);
         $quizTwo = Quiz::create([
-            'title' => "Sample Quiz",
+            'name' => "Sample Quiz",
             'slug' => "sample-quiz-two",
             'description' => "",
             'media_url' => null,
@@ -195,7 +195,6 @@ class QuizTest extends TestCase
             'pass_marks' => 0,
             'max_attempts' => 0,
             'is_published' => 1,
-            'media_url' => null,
             'media_type' => 'image',
             'duration' => 0,
             'valid_from' => date('Y-m-d H:i:s'),
@@ -204,7 +203,7 @@ class QuizTest extends TestCase
         $quizTwo = Quiz::find($quizTwo->id);
         $this->assertEquals(true, $quizTwo->negative_marking_settings['enable_negative_marks']);
         $quizThree = Quiz::factory()->make()->create([
-            'title' => 'Sample Quiz',
+            'name' => 'Sample Quiz',
             'slug' => 'sample-quiz-3',
             'negative_marking_settings' => [
                 'enable_negative_marks' => true,

--- a/tests/Unit/TopicTest.php
+++ b/tests/Unit/TopicTest.php
@@ -15,20 +15,20 @@ class TopicTest extends TestCase
     function topic()
     {
         $topic = Topic::factory()->create([
-            'topic' => 'Test Topic',
+            'name' => 'Test Topic',
         ]);
-        $this->assertEquals('Test Topic', $topic->topic);
+        $this->assertEquals('Test Topic', $topic->name);
     }
 
     /** @test */
     function topic_parent_child_relation()
     {
         $parentTopic = Topic::factory()->create([
-            'topic' => 'Parent Topic',
+            'name' => 'Parent Topic',
         ]);
         $parentTopic->children()->saveMany([
-            Topic::factory()->make(['topic' => 'Child Topic 1']),
-            Topic::factory()->make(['topic' => 'Child Topic 2']),
+            Topic::factory()->make(['name' => 'Child Topic 1']),
+            Topic::factory()->make(['name' => 'Child Topic 2']),
         ]);
         $this->assertEquals(2, $parentTopic->children()->count());
     }
@@ -37,16 +37,16 @@ class TopicTest extends TestCase
     function topic_question_relation()
     {
         $topic = Topic::factory()->create([
-            'topic' => 'Test Topic',
+            'name' => 'Test Topic',
         ]);
         $question1 = Question::factory()->create([
-            'question' => 'Test Question',
+            'name' => 'Test Question',
         ]);
         $question2 = Question::factory()->create([
-            'question' => 'Test Question',
+            'name' => 'Test Question',
         ]);
         $question3 = Question::factory()->create([
-            'question' => 'Test Question',
+            'name' => 'Test Question',
         ]);
         $topic->questions()->attach($question1);
         $topic->questions()->attach([$question2->id, $question3->id]);


### PR DESCRIPTION
Rename the model field names as seen in most popular packages. For example rename the question to name in order to use the formula $question->name instead of $question->question to avoid confusion. Preserve backwards compatible with the current names