### PR TITLE
Rout key name slug

### DIFF
--- a/src/Models/Quiz.php
+++ b/src/Models/Quiz.php
@@ -101,4 +101,9 @@ class Quiz extends Model
     {
         return $this->hasMany(config('laravel-quiz.models.quiz_author'));
     }
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
 }

--- a/src/Models/Topic.php
+++ b/src/Models/Topic.php
@@ -73,4 +73,9 @@ class Topic extends Model
     {
         return TopicFactory::new();
     }
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
 }


### PR DESCRIPTION
For the entities with a slug it would be helpful to change the default search from Laravel from id to the slug. Then this search would work:

```
// routes
Route::get('/quiz/{quiz}', [QuizController::class, 'edit']);


// Quiz model
public function getRouteKeyName()
{
    return 'slug';
}

// controller
public function edit(Quiz $quiz)
{
    dd($quiz);
}

```